### PR TITLE
Add service nature handling and fixed cost price configuration

### DIFF
--- a/admin/setup.php
+++ b/admin/setup.php
@@ -138,8 +138,10 @@ print '<table class="noborder" width="100%">';
 
 // Réglage 
 		setup_print_title($langs->trans("LMDB_UpdateOptions"));
-		setup_print_on_off('LMDB_COST_PRICE_ONLY');
-		setup_print_on_off('LMDB_SUPPLIER_BUYPRICE_ALTERED');
+                setup_print_on_off('LMDB_COST_PRICE_ONLY');
+                setup_print_on_off('LMDB_SUPPLIER_BUYPRICE_ALTERED');
+                setup_print_on_off('LMDB_COST_PRICE_FIXED_FEES_MODE');
+                setup_print_input_form_part('LMDB_COST_PRICE_FIXED_FEES_COEF', '', '', array('type' => 'number', 'step' => '0.01', 'min' => '0'));
 		
 
 

--- a/langs/en_US/dynamicsprices.lang
+++ b/langs/en_US/dynamicsprices.lang
@@ -18,6 +18,9 @@ DynamicsPricesSetupPage = Dynamic sales price module settings page<br>
 LMDB_UpdateOptions = Sales price update options<br>
 LMDB_COST_PRICE_ONLY = Update sales prices based on cost prices only.
 LMDB_SUPPLIER_BUYPRICE_ALTERED = Update sales prices when creating/updating/deleting a purchase price, or when updating the cost price if cost-based calculation is enabled.
+LMDB_COST_PRICE_FIXED_FEES_MODE = Compute cost price from the average supplier price multiplied by a fixed overhead coefficient.
+LMDB_COST_PRICE_FIXED_FEES_COEF = Fixed overhead coefficient for cost price calculation
+LMDB_COST_PRICE_FIXED_FEES_COEF_HELP = Enter the coefficient (e.g. 1.15 adds 15% overhead) applied to the average supplier price.
 <br>
 #<br>
 # About page<br>
@@ -52,4 +55,9 @@ Minrate = Minimum margin rate (in %)<br>
 LMDB_CommentAutoUpdateSellPrice = Sales prices are updated based on the price coefficients given in the dictionary and the average of the Supplier purchase unit prices.<br>
 LMDB_LabelAutoUpdateSellPrice = Automatic update of sales prices<br>
 LMDB_coefprice = Margin rates on sales prices<br>
+LMDB_ElementTypeTooltipHelp = Choose 0 to apply the coefficient to products and 1 for services.<br>
+LMDB_ServiceNature = Service nature<br>
+LMDB_ServiceNatureDictionary = Service natures<br>
+LMDB_ServiceNatureLabelTooltipHelp = Label of the service nature.<br>
+LMDB_ServiceNaturePositionTooltipHelp = Display order of the service nature.<br>
 DynamicsPrices = Dynamic sales prices

--- a/langs/es_ES/dynamicsprices.lang
+++ b/langs/es_ES/dynamicsprices.lang
@@ -18,6 +18,9 @@ DynamicsPricesSetupPage = Página de configuración del módulo de precios de ve
 LMDB_UpdateOptions = Opciones de actualización de precios de venta<br>
 LMDB_COST_PRICE_ONLY = Actualizar los precios de venta según los precios de coste Solo.
 LMDB_SUPPLIER_BUYPRICE_ALTERED = Actualizar los precios de venta al crear, actualizar o eliminar un precio de compra, o al actualizar el precio de costo si el cálculo basado en costos está habilitado. <br>
+LMDB_COST_PRICE_FIXED_FEES_MODE = Calcular el precio de coste a partir del promedio de precios de compra multiplicado por un coeficiente de gastos fijos.<br>
+LMDB_COST_PRICE_FIXED_FEES_COEF = Coeficiente de gastos fijos para el cálculo del precio de coste<br>
+LMDB_COST_PRICE_FIXED_FEES_COEF_HELP = Indique el coeficiente (por ejemplo 1,15 añade un 15 % de gastos) aplicado al promedio de precios de compra.<br>
 #<br>
 # Acerca de <br>
 #<br>
@@ -51,4 +54,9 @@ Minrate = Tasa de margen mínima (en %)<br>
 LMDB_CommentAutoUpdateSellPrice = Los precios de venta se actualizan según los coeficientes de precio del diccionario y el promedio de los precios unitarios de compra del proveedor.<br>
 LMDB_LabelAutoUpdateSellPrice = Actualización automática de precios de venta<br>
 LMDB_coefprice = Tasas de margen sobre los precios de venta<br>
+LMDB_ElementTypeTooltipHelp = Seleccione 0 para aplicar el coeficiente a los productos y 1 a los servicios.<br>
+LMDB_ServiceNature = Naturaleza del servicio<br>
+LMDB_ServiceNatureDictionary = Naturalezas de servicios<br>
+LMDB_ServiceNatureLabelTooltipHelp = Etiqueta de la naturaleza del servicio.<br>
+LMDB_ServiceNaturePositionTooltipHelp = Orden de visualización de la naturaleza del servicio.<br>
 DynamicsPrices = Precios de venta dinámicos

--- a/langs/fr_FR/dynamicsprices.lang
+++ b/langs/fr_FR/dynamicsprices.lang
@@ -19,6 +19,9 @@ LMDB_UpdateOptions=Options de mise à jour des prix de vente
 
 LMDB_COST_PRICE_ONLY = Ne mettre à jour les prix de vente que sur la base des prix de revient.
 LMDB_SUPPLIER_BUYPRICE_ALTERED = Actualisation de prix de vente à la création/mise à jour/suppression d'un prix d'achat ou l'actualisation du prix de revient si le calcul sur le prix de revient est activé.
+LMDB_COST_PRICE_FIXED_FEES_MODE = Calculer le prix de revient à partir de la moyenne des prix d'achat multipliée par un coefficient de frais fixes.
+LMDB_COST_PRICE_FIXED_FEES_COEF = Coefficient de frais fixes pour le calcul du prix de revient
+LMDB_COST_PRICE_FIXED_FEES_COEF_HELP = Indiquez le coefficient (ex : 1,15 pour ajouter 15 % de frais fixes) appliqué à la moyenne des prix d'achat.
 
 
 
@@ -56,4 +59,9 @@ Entity = Entité
 LMDB_CommentAutoUpdateSellPrice = Les prix de vente sont mis à jour en fonction des coefficients de prix donnés dans le dictionnaire, et de la moyenne des prix unitaires d'achats fournisseurs.
 LMDB_LabelAutoUpdateSellPrice = Mise à jour automatique des prix de vente
 LMDB_coefprice = Taux de marges sur les prix de vente
+LMDB_ElementTypeTooltipHelp = Choisissez 0 pour appliquer le coefficient aux produits et 1 pour les services.
+LMDB_ServiceNature = Nature du service
+LMDB_ServiceNatureDictionary = Natures de services
+LMDB_ServiceNatureLabelTooltipHelp = Libellé de la nature de service.
+LMDB_ServiceNaturePositionTooltipHelp = Ordre d'affichage de la nature de service.
 DynamicsPrices = Prix de vente dynamiques

--- a/sql/dolibarr_allversions.sql
+++ b/sql/dolibarr_allversions.sql
@@ -1,13 +1,29 @@
 --
 -- Script run when an upgrade of Dolibarr is done. Whatever is the Dolibarr version.
 --
-CREATE TABLE IF NOT EXISTS `llx_c_coefprice`( 
-  	`rowid`				int(11) AUTO_INCREMENT,
-  	`code` 			VARCHAR(255) NOT NULL UNIQUE, 
-  	`label` 			VARCHAR(255) NOT NULL,   
-	`targetrate`      FLOAT(24.8) NOT NULL,
-	`minrate`      FLOAT(24.8) NOT NULL,
-	`active`           	TINYINT(4)    NOT NULL DEFAULT 1,
+CREATE TABLE IF NOT EXISTS `llx_c_coefprice`(
+        `rowid`                         int(11) AUTO_INCREMENT,
+        `code`                  VARCHAR(255) NOT NULL UNIQUE,
+        `label`                         VARCHAR(255) NOT NULL,
+        `targetrate`      FLOAT(24.8) NOT NULL,
+        `minrate`      FLOAT(24.8) NOT NULL,
+        `element_type`          TINYINT(4)    NOT NULL DEFAULT 0,
+        `active`                TINYINT(4)    NOT NULL DEFAULT 1,
 
-	PRIMARY KEY (`rowid`) 
+        PRIMARY KEY (`rowid`)
+)ENGINE=innodb DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ;
+
+ALTER TABLE `llx_c_coefprice`
+        ADD COLUMN IF NOT EXISTS `element_type` TINYINT(4) NOT NULL DEFAULT 0;
+
+CREATE TABLE IF NOT EXISTS `llx_c_service_nature`(
+        `rowid`         int(11) AUTO_INCREMENT,
+        `entity`        int(11) NOT NULL DEFAULT 1,
+        `code`          VARCHAR(64) NOT NULL,
+        `label`         VARCHAR(255) NOT NULL,
+        `active`        TINYINT(4) NOT NULL DEFAULT 1,
+        `position`      int(11) NOT NULL DEFAULT 0,
+
+        PRIMARY KEY (`rowid`),
+        UNIQUE KEY uk_service_nature_code (`code`,`entity`)
 )ENGINE=innodb DEFAULT CHARACTER SET utf8 COLLATE utf8_unicode_ci ;

--- a/sql/llx_c_coefprice.sql
+++ b/sql/llx_c_coefprice.sql
@@ -1,13 +1,17 @@
 --
 -- Script run when an upgrade of Dolibarr is done. Whatever is the Dolibarr version.
 --
-CREATE TABLE IF NOT EXISTS `llx_c_coefprice`( 
-  	`rowid` integer  AUTO_INCREMENT PRIMARY KEY NOT NULL,
-  	`entity` integer NOT NULL DEFAULT '1',
-	`code` varchar(10) DEFAULT NULL,
-	`fk_nature` varchar(10) DEFAULT NULL,
-	`pricelevel` integer NOT NULL,
-	`targetrate` float NOT NULL,
-	`minrate` float NOT NULL,
-	`active` tinyint NOT NULL DEFAULT '1'
+CREATE TABLE IF NOT EXISTS `llx_c_coefprice`(
+        `rowid` integer  AUTO_INCREMENT PRIMARY KEY NOT NULL,
+        `entity` integer NOT NULL DEFAULT '1',
+        `code` varchar(10) DEFAULT NULL,
+        `fk_nature` varchar(10) DEFAULT NULL,
+        `pricelevel` integer NOT NULL,
+        `targetrate` float NOT NULL,
+        `minrate` float NOT NULL,
+        `element_type` tinyint NOT NULL DEFAULT '0',
+        `active` tinyint NOT NULL DEFAULT '1'
 )ENGINE=innodb;
+
+ALTER TABLE `llx_c_coefprice`
+        ADD COLUMN IF NOT EXISTS `element_type` tinyint NOT NULL DEFAULT '0';


### PR DESCRIPTION
## Summary
- add setup options to enable a fixed-fees cost price mode and configure the coefficient
- register a service nature dictionary, create the related service extrafield, and scope coefficient dictionaries to products or services
- update the pricing helpers to honour the new options, support services via nature lookup, and extend SQL definitions for the new data structures

## Testing
- php -l admin/setup.php
- php -l core/modules/modDynamicsPrices.class.php
- php -l lib/dynamicsprices.lib.php

------
https://chatgpt.com/codex/tasks/task_e_68e3c0e8c64c832e983611b1cac30387