### PR TITLE
FIX: Corrige inclusion fatale dans admin/about.php de DynamicsPrices

### DIFF
--- a/admin/about.php
+++ b/admin/about.php
@@ -16,9 +16,9 @@
  */
 
 /**
- * \file		diffusion/admin/about.php
- * \ingroup	diffusion
- * \brief	About page of Diffusion module.
+ * \file		dynamicsprices/admin/about.php
+ * \ingroup	dynamicsprices
+ * \brief	About page of DynamicsPrices module.
  */
 
 // Load Dolibarr environment
@@ -51,27 +51,27 @@ if (!$res) {
 }
 
 require_once DOL_DOCUMENT_ROOT.'/core/lib/admin.lib.php';
-require_once '../lib/diffusion.lib.php';
-require_once '../core/modules/modDiffusion.class.php';
+require_once '../lib/dynamicsprices.lib.php';
+require_once '../core/modules/modDynamicsPrices.class.php';
 
 // Load translations required by this page.
-$langs->loadLangs(array('admin', 'diffusion@diffusion'));
+$langs->loadLangs(array('admin', 'dynamicsprices@dynamicsprices'));
 
 // Restrict access to administrators only.
 if (empty($user->admin)) {
 	accessforbidden();
 }
 
-$moduleDescriptor = new modDiffusion($db);
-$title = $langs->trans('DiffusionAbout');
+$moduleDescriptor = new modDynamicsPrices($db);
+$title = $langs->trans('LMDB_AboutTitle');
 
 llxHeader('', $title);
 
 print load_fiche_titre($title, '', 'info');
-$head = diffusionAdminPrepareHead();
-print dol_get_fiche_head($head, 'about', $title, -1, 'diffusion@diffusion');
+$head = dynamicspricesAdminPrepareHead();
+print dol_get_fiche_head($head, 'about', $title, -1, 'dynamicsprices@dynamicsprices');
 
-print '<div class="underbanner opacitymedium">'.$langs->trans('DiffusionAboutPage').'</div>';
+print '<div class="underbanner opacitymedium">'.$langs->trans('LMDB_AboutDescription').'</div>';
 print '<br>';
 
 print '<div class="fichecenter">';
@@ -80,11 +80,11 @@ print '<div class="fichecenter">';
 print '<div class="fichehalfleft">';
 print '<div class="div-table-responsive-no-min">';
 print '<table class="noborder centpercent">';
-print '<tr class="liste_titre"><th colspan="2">'.$langs->trans('DiffusionAboutGeneral').'</th></tr>';
-print '<tr class="oddeven"><td class="titlefield">'.$langs->trans('DiffusionAboutVersion').'</td><td>'.dol_escape_htmltag($moduleDescriptor->version).'</td></tr>';
-print '<tr class="oddeven"><td class="titlefield">'.$langs->trans('DiffusionAboutFamily').'</td><td>'.dol_escape_htmltag($moduleDescriptor->family).'</td></tr>';
-print '<tr class="oddeven"><td class="titlefield">'.$langs->trans('DiffusionAboutDescription').'</td><td>'.dol_escape_htmltag($langs->trans($moduleDescriptor->description)).'</td></tr>';
-print '<tr class="oddeven"><td class="titlefield">'.$langs->trans('DiffusionAboutMaintainer').'</td><td>'.dol_escape_htmltag($moduleDescriptor->editor_name).'</td></tr>';
+print '<tr class="liste_titre"><th colspan="2">'.$langs->trans('LMDB_AboutGeneral').'</th></tr>';
+print '<tr class="oddeven"><td class="titlefield">'.$langs->trans('LMDB_AboutVersion').'</td><td>'.dol_escape_htmltag($moduleDescriptor->version).'</td></tr>';
+print '<tr class="oddeven"><td class="titlefield">'.$langs->trans('LMDB_AboutFamily').'</td><td>'.dol_escape_htmltag($moduleDescriptor->family).'</td></tr>';
+print '<tr class="oddeven"><td class="titlefield">'.$langs->trans('LMDB_AboutModuleDescription').'</td><td>'.dol_escape_htmltag($langs->trans($moduleDescriptor->description)).'</td></tr>';
+print '<tr class="oddeven"><td class="titlefield">'.$langs->trans('LMDB_AboutMaintainer').'</td><td>'.dol_escape_htmltag($moduleDescriptor->editor_name).'</td></tr>';
 print '</table>';
 print '</div>';
 print '</div>';
@@ -93,10 +93,10 @@ print '</div>';
 print '<div class="fichehalfright">';
 print '<div class="div-table-responsive-no-min">';
 print '<table class="noborder centpercent">';
-print '<tr class="liste_titre"><th colspan="2">'.$langs->trans('DiffusionAboutResources').'</th></tr>';
-print '<tr class="oddeven"><td class="titlefield">'.$langs->trans('DiffusionAboutDocumentation').'</td><td><a href="'.dol_buildpath('/diffusion/README.md', 1).'" target="_blank" rel="noopener">'.$langs->trans('DiffusionAboutDocumentationLink').'</a></td></tr>';
-print '<tr class="oddeven"><td class="titlefield">'.$langs->trans('DiffusionAboutSupport').'</td><td>'.dol_escape_htmltag($langs->trans('DiffusionAboutSupportValue')).'</td></tr>';
-print '<tr class="oddeven"><td class="titlefield">'.$langs->trans('DiffusionAboutContact').'</td><td><a href="https://'.dol_escape_htmltag($moduleDescriptor->editor_url).'" target="_blank" rel="noopener">'.dol_escape_htmltag($moduleDescriptor->editor_url).'</a></td></tr>';
+print '<tr class="liste_titre"><th colspan="2">'.$langs->trans('LMDB_AboutResources').'</th></tr>';
+print '<tr class="oddeven"><td class="titlefield">'.$langs->trans('LMDB_AboutDocumentation').'</td><td><a href="'.dol_buildpath('/dynamicsprices/README.md', 1).'" target="_blank" rel="noopener">'.$langs->trans('LMDB_AboutDocumentationLink').'</a></td></tr>';
+print '<tr class="oddeven"><td class="titlefield">'.$langs->trans('LMDB_AboutSupport').'</td><td>'.dol_escape_htmltag($langs->trans('LMDB_AboutSupportValue')).'</td></tr>';
+print '<tr class="oddeven"><td class="titlefield">'.$langs->trans('LMDB_AboutContact').'</td><td><a href="https://'.dol_escape_htmltag($moduleDescriptor->editor_url).'" target="_blank" rel="noopener">'.dol_escape_htmltag($moduleDescriptor->editor_url).'</a></td></tr>';
 print '</table>';
 print '</div>';
 print '</div>';

--- a/admin/setup.php
+++ b/admin/setup.php
@@ -136,7 +136,9 @@ function dynamicspricesGetCommercialCategoryOptions($db)
 	}
 
 	while ($obj = $db->fetch_object($resql)) {
-		$options[$obj->code] = $obj->label.' ('.$obj->code.')';
+		$label = $obj->label.' ('.$obj->code.')';
+		$options[$obj->code] = $label;
+		$options[(string) $obj->rowid] = $label;
 	}
 
 	return $options;
@@ -156,20 +158,25 @@ function dynamicspricesInjectCommercialCategorySelect($html, $form, $options)
 		return $html;
 	}
 
-	return preg_replace_callback(
-		'/<input\b[^>]*name=[\"\']code_commercial_category[\"\'][^>]*>/i',
-		function ($matches) use ($form, $options) {
-			$input = $matches[0];
-			$selected = 0;
-			if (preg_match('/value=[\"\']([^\"\']*)[\"\']/i', $input, $valueMatch)) {
-				$selected = $valueMatch[1];
-			} else {
-				$selected = GETPOST('code_commercial_category', 'aZ09');
-			}
-			return $form->selectarray('code_commercial_category', $options, $selected, 0, 0, 0, '', 0, 0, 0, '', 'minwidth300');
-		},
-		$html
-	);
+	$fieldNames = array('code_commercial_category', 'fk_commercial_category', 'fk_nature', 'code_nature');
+	foreach ($fieldNames as $fieldName) {
+		$html = preg_replace_callback(
+			'/<input\b[^>]*name=[\"\']'.preg_quote($fieldName, '/').'[\"\'][^>]*>/i',
+			function ($matches) use ($form, $options, $fieldName) {
+				$input = $matches[0];
+				$selected = '';
+				if (preg_match('/value=[\"\']([^\"\']*)[\"\']/i', $input, $valueMatch)) {
+					$selected = $valueMatch[1];
+				} else {
+					$selected = GETPOST($fieldName, 'aZ09');
+				}
+				return $form->selectarray($fieldName, $options, $selected, 0, 0, 0, '', 0, 0, 0, '', 'minwidth300');
+			},
+			$html
+		);
+	}
+
+	return $html;
 }
 
 

--- a/admin/setup.php
+++ b/admin/setup.php
@@ -136,9 +136,7 @@ function dynamicspricesGetCommercialCategoryOptions($db)
 	}
 
 	while ($obj = $db->fetch_object($resql)) {
-		$label = $obj->label.' ('.$obj->code.')';
-		$options[$obj->code] = $label;
-		$options[(string) $obj->rowid] = $label;
+		$options[$obj->code] = $obj->label.' ('.$obj->code.')';
 	}
 
 	return $options;
@@ -158,25 +156,20 @@ function dynamicspricesInjectCommercialCategorySelect($html, $form, $options)
 		return $html;
 	}
 
-	$fieldNames = array('code_commercial_category', 'fk_commercial_category', 'fk_nature', 'code_nature');
-	foreach ($fieldNames as $fieldName) {
-		$html = preg_replace_callback(
-			'/<input\b[^>]*name=[\"\']'.preg_quote($fieldName, '/').'[\"\'][^>]*>/i',
-			function ($matches) use ($form, $options, $fieldName) {
-				$input = $matches[0];
-				$selected = '';
-				if (preg_match('/value=[\"\']([^\"\']*)[\"\']/i', $input, $valueMatch)) {
-					$selected = $valueMatch[1];
-				} else {
-					$selected = GETPOST($fieldName, 'aZ09');
-				}
-				return $form->selectarray($fieldName, $options, $selected, 0, 0, 0, '', 0, 0, 0, '', 'minwidth300');
-			},
-			$html
-		);
-	}
-
-	return $html;
+	return preg_replace_callback(
+		'/<input\b[^>]*name=[\"\']code_commercial_category[\"\'][^>]*>/i',
+		function ($matches) use ($form, $options) {
+			$input = $matches[0];
+			$selected = 0;
+			if (preg_match('/value=[\"\']([^\"\']*)[\"\']/i', $input, $valueMatch)) {
+				$selected = $valueMatch[1];
+			} else {
+				$selected = GETPOST('code_commercial_category', 'aZ09');
+			}
+			return $form->selectarray('code_commercial_category', $options, $selected, 0, 0, 0, '', 0, 0, 0, '', 'minwidth300');
+		},
+		$html
+	);
 }
 
 

--- a/core/modules/modDynamicsPrices.class.php
+++ b/core/modules/modDynamicsPrices.class.php
@@ -254,12 +254,6 @@ class modDynamicsPrices extends DolibarrModules
 		 */
 /* BEGIN MODULEBUILDER DICTIONARIES */
 		$commercialCategoryHasEntity = $this->columnExists(MAIN_DB_PREFIX."c_commercial_category", 'entity');
-		$coefCategoryColumn = $this->getFirstExistingColumn(MAIN_DB_PREFIX."c_coefprice", array('code_commercial_category', 'fk_commercial_category', 'fk_nature'));
-		$marginCategoryColumn = $this->getFirstExistingColumn(MAIN_DB_PREFIX."c_margin_on_cost", array('code_commercial_category', 'fk_commercial_category', 'code_nature'));
-		$coefCategoryJoin = $this->buildCommercialCategoryJoinCondition('t', $coefCategoryColumn);
-		$marginCategoryJoin = $this->buildCommercialCategoryJoinCondition('t', $marginCategoryColumn);
-		$coefCategoryField = $coefCategoryColumn ? $coefCategoryColumn : 'code_commercial_category';
-		$marginCategoryField = $marginCategoryColumn ? $marginCategoryColumn : 'code_commercial_category';
 		$commercialCategorySelectSql = $commercialCategoryHasEntity
 			? 'SELECT t.rowid as rowid, t.entity, t.code, t.label, t.active FROM '.MAIN_DB_PREFIX.'c_commercial_category AS t WHERE t.entity = '.((int) $conf->entity)
 			: 'SELECT t.rowid as rowid, t.code, t.label, t.active FROM '.MAIN_DB_PREFIX.'c_commercial_category AS t';
@@ -270,8 +264,8 @@ class modDynamicsPrices extends DolibarrModules
 			'tabname' => array(MAIN_DB_PREFIX."c_coefprice", MAIN_DB_PREFIX."c_margin_on_cost", MAIN_DB_PREFIX."c_commercial_category"),
 			'tablib' => array("LMDB_coefprice", "LMDB_marginoncost", "LMDB_commercialcategories"),
 			'tabsql' => array(
-				'SELECT t.rowid as rowid, t.entity, t.code, t.'.$coefCategoryField.' as '.$coefCategoryField.', cc.label as commercial_category_label, t.pricelevel, t.minrate, t.targetrate, t.active FROM '.MAIN_DB_PREFIX.'c_coefprice AS t LEFT JOIN '.MAIN_DB_PREFIX.'c_commercial_category as cc ON '.$coefCategoryJoin.' WHERE t.entity = '.((int) $conf->entity),
-				'SELECT t.rowid as rowid, t.entity, t.code, t.'.$marginCategoryField.' as '.$marginCategoryField.', cc.label as commercial_category_label, t.margin_on_cost_percent, t.active FROM '.MAIN_DB_PREFIX.'c_margin_on_cost AS t LEFT JOIN '.MAIN_DB_PREFIX.'c_commercial_category as cc ON '.$marginCategoryJoin.' WHERE t.entity = '.((int) $conf->entity),
+				'SELECT t.rowid as rowid, t.entity, t.code, t.code_commercial_category, cc.label as commercial_category_label, t.pricelevel, t.minrate, t.targetrate, t.active FROM '.MAIN_DB_PREFIX.'c_coefprice AS t LEFT JOIN '.MAIN_DB_PREFIX.'c_commercial_category as cc ON cc.code = t.code_commercial_category WHERE t.entity = '.((int) $conf->entity),
+				'SELECT t.rowid as rowid, t.entity, t.code, t.code_commercial_category, cc.label as commercial_category_label, t.margin_on_cost_percent, t.active FROM '.MAIN_DB_PREFIX.'c_margin_on_cost AS t LEFT JOIN '.MAIN_DB_PREFIX.'c_commercial_category as cc ON cc.code = t.code_commercial_category WHERE t.entity = '.((int) $conf->entity),
 				$commercialCategorySelectSql,
 			),
 			'tabsqlsort' => array(
@@ -280,18 +274,18 @@ class modDynamicsPrices extends DolibarrModules
 				"label ASC",
 			),
 			'tabfield' => array(
-				"code,".$coefCategoryField.",pricelevel,targetrate,minrate",
-				"code,".$marginCategoryField.",margin_on_cost_percent",
+				"code,code_commercial_category,pricelevel,targetrate,minrate",
+				"code,code_commercial_category,margin_on_cost_percent",
 				"code,label",
 			),
 			'tabfieldvalue' => array(
-				"code,entity,".$coefCategoryField.",pricelevel,targetrate,minrate",
-				"code,entity,".$marginCategoryField.",margin_on_cost_percent",
+				"code,entity,code_commercial_category,pricelevel,targetrate,minrate",
+				"code,entity,code_commercial_category,margin_on_cost_percent",
 				$commercialCategoryFieldValue,
 			),
 			'tabfieldinsert' => array(
-				"code,entity,".$coefCategoryField.",pricelevel,targetrate,minrate",
-				"code,entity,".$marginCategoryField.",margin_on_cost_percent",
+				"code,entity,code_commercial_category,pricelevel,targetrate,minrate",
+				"code,entity,code_commercial_category,margin_on_cost_percent",
 				$commercialCategoryFieldValue,
 			),
 			'tabrowid' => array('rowid', 'rowid', 'rowid'),
@@ -304,9 +298,6 @@ class modDynamicsPrices extends DolibarrModules
 				'code' => $langs->trans('LMDB_CodeTooltipHelp'),
 				'entity' => $langs->trans('LMDB_ENtityTooltipHelp'),
 				'code_commercial_category' => $langs->trans('LMDB_CodeCommercialCategoryTooltipHelp'),
-				'fk_commercial_category' => $langs->trans('LMDB_FkCommercialCategoryTooltipHelp'),
-				'fk_nature' => $langs->trans('LMDB_FkNatureTooltipHelp'),
-				'code_nature' => $langs->trans('LMDB_CodeNatureTooltipHelp'),
 				'pricelevel' => $langs->trans('LMDB_PriceLevelTooltipHelp'),
 				'targetrate' => $langs->trans('LMDB_TargetRateTooltipHelp'),
 				'minrate' => $langs->trans('LMDB_MinRateTooltipHelp'),
@@ -559,6 +550,10 @@ class modDynamicsPrices extends DolibarrModules
 		if ($result < 0) {
 			return -1; // Do not activate module if error 'not allowed' returned when loading module SQL queries (the _load_table run sql with run_sql with the error allowed parameter set to 'default')
 		}
+		$result = $this->ensureCommercialCategoryColumns();
+		if ($result < 0) {
+			return -1;
+		}
 
 		// Create product/service extrafield during init.
 		include_once DOL_DOCUMENT_ROOT.'/core/class/extrafields.class.php';
@@ -646,41 +641,36 @@ class modDynamicsPrices extends DolibarrModules
 	}
 
 	/**
-	 * Return first existing column from a list.
+	 * Add and populate code_commercial_category columns for module dictionaries.
 	 *
-	 * @param string $tableName Table name
-	 * @param array<int,string> $columnNames Ordered column list
-	 * @return string
+	 * @return int
 	 */
-	private function getFirstExistingColumn($tableName, $columnNames)
+	private function ensureCommercialCategoryColumns()
 	{
-		foreach ($columnNames as $columnName) {
-			if ($this->columnExists($tableName, $columnName)) {
-				return $columnName;
+		$queries = array();
+
+		if (!$this->columnExists(MAIN_DB_PREFIX."c_coefprice", 'code_commercial_category')) {
+			$queries[] = "ALTER TABLE ".MAIN_DB_PREFIX."c_coefprice ADD COLUMN code_commercial_category VARCHAR(50) DEFAULT NULL";
+		}
+		if (!$this->columnExists(MAIN_DB_PREFIX."c_margin_on_cost", 'code_commercial_category')) {
+			$queries[] = "ALTER TABLE ".MAIN_DB_PREFIX."c_margin_on_cost ADD COLUMN code_commercial_category VARCHAR(50) DEFAULT NULL";
+		}
+		if ($this->columnExists(MAIN_DB_PREFIX."c_coefprice", 'fk_nature')) {
+			$queries[] = "UPDATE ".MAIN_DB_PREFIX."c_coefprice SET code_commercial_category = fk_nature WHERE (code_commercial_category IS NULL OR code_commercial_category = '') AND fk_nature IS NOT NULL AND fk_nature <> ''";
+		}
+		if ($this->columnExists(MAIN_DB_PREFIX."c_margin_on_cost", 'code_nature')) {
+			$queries[] = "UPDATE ".MAIN_DB_PREFIX."c_margin_on_cost SET code_commercial_category = code_nature WHERE (code_commercial_category IS NULL OR code_commercial_category = '') AND code_nature IS NOT NULL AND code_nature <> ''";
+		}
+
+		foreach ($queries as $sql) {
+			$resql = $this->db->query($sql);
+			if (!$resql) {
+				$this->error = $this->db->lasterror();
+				return -1;
 			}
 		}
 
-		return '';
-	}
-
-	/**
-	 * Build SQL join condition between dictionary table and commercial category table.
-	 *
-	 * @param string $tableAlias Alias of dictionary table
-	 * @param string $columnName Commercial category column on dictionary table
-	 * @return string
-	 */
-	private function buildCommercialCategoryJoinCondition($tableAlias, $columnName)
-	{
-		if (empty($columnName)) {
-			return '1 = 0';
-		}
-
-		if (preg_match('/^fk_/', $columnName)) {
-			return 'cc.rowid = '.$tableAlias.'.'.$columnName;
-		}
-
-		return 'cc.code = '.$tableAlias.'.'.$columnName;
+		return 1;
 	}
 
 	/**

--- a/core/modules/modDynamicsPrices.class.php
+++ b/core/modules/modDynamicsPrices.class.php
@@ -254,6 +254,12 @@ class modDynamicsPrices extends DolibarrModules
 		 */
 /* BEGIN MODULEBUILDER DICTIONARIES */
 		$commercialCategoryHasEntity = $this->columnExists(MAIN_DB_PREFIX."c_commercial_category", 'entity');
+		$coefCategoryColumn = $this->getFirstExistingColumn(MAIN_DB_PREFIX."c_coefprice", array('code_commercial_category', 'fk_commercial_category', 'fk_nature'));
+		$marginCategoryColumn = $this->getFirstExistingColumn(MAIN_DB_PREFIX."c_margin_on_cost", array('code_commercial_category', 'fk_commercial_category', 'code_nature'));
+		$coefCategoryJoin = $this->buildCommercialCategoryJoinCondition('t', $coefCategoryColumn);
+		$marginCategoryJoin = $this->buildCommercialCategoryJoinCondition('t', $marginCategoryColumn);
+		$coefCategoryField = $coefCategoryColumn ? $coefCategoryColumn : 'code_commercial_category';
+		$marginCategoryField = $marginCategoryColumn ? $marginCategoryColumn : 'code_commercial_category';
 		$commercialCategorySelectSql = $commercialCategoryHasEntity
 			? 'SELECT t.rowid as rowid, t.entity, t.code, t.label, t.active FROM '.MAIN_DB_PREFIX.'c_commercial_category AS t WHERE t.entity = '.((int) $conf->entity)
 			: 'SELECT t.rowid as rowid, t.code, t.label, t.active FROM '.MAIN_DB_PREFIX.'c_commercial_category AS t';
@@ -264,8 +270,8 @@ class modDynamicsPrices extends DolibarrModules
 			'tabname' => array(MAIN_DB_PREFIX."c_coefprice", MAIN_DB_PREFIX."c_margin_on_cost", MAIN_DB_PREFIX."c_commercial_category"),
 			'tablib' => array("LMDB_coefprice", "LMDB_marginoncost", "LMDB_commercialcategories"),
 			'tabsql' => array(
-				'SELECT t.rowid as rowid, t.entity, t.code, t.code_commercial_category, cc.label as commercial_category_label, t.pricelevel, t.minrate, t.targetrate, t.active FROM '.MAIN_DB_PREFIX.'c_coefprice AS t LEFT JOIN '.MAIN_DB_PREFIX.'c_commercial_category as cc ON cc.code = t.code_commercial_category WHERE t.entity = '.((int) $conf->entity),
-				'SELECT t.rowid as rowid, t.entity, t.code, t.code_commercial_category, cc.label as commercial_category_label, t.margin_on_cost_percent, t.active FROM '.MAIN_DB_PREFIX.'c_margin_on_cost AS t LEFT JOIN '.MAIN_DB_PREFIX.'c_commercial_category as cc ON cc.code = t.code_commercial_category WHERE t.entity = '.((int) $conf->entity),
+				'SELECT t.rowid as rowid, t.entity, t.code, t.'.$coefCategoryField.' as '.$coefCategoryField.', cc.label as commercial_category_label, t.pricelevel, t.minrate, t.targetrate, t.active FROM '.MAIN_DB_PREFIX.'c_coefprice AS t LEFT JOIN '.MAIN_DB_PREFIX.'c_commercial_category as cc ON '.$coefCategoryJoin.' WHERE t.entity = '.((int) $conf->entity),
+				'SELECT t.rowid as rowid, t.entity, t.code, t.'.$marginCategoryField.' as '.$marginCategoryField.', cc.label as commercial_category_label, t.margin_on_cost_percent, t.active FROM '.MAIN_DB_PREFIX.'c_margin_on_cost AS t LEFT JOIN '.MAIN_DB_PREFIX.'c_commercial_category as cc ON '.$marginCategoryJoin.' WHERE t.entity = '.((int) $conf->entity),
 				$commercialCategorySelectSql,
 			),
 			'tabsqlsort' => array(
@@ -274,18 +280,18 @@ class modDynamicsPrices extends DolibarrModules
 				"label ASC",
 			),
 			'tabfield' => array(
-				"code,code_commercial_category,pricelevel,targetrate,minrate",
-				"code,code_commercial_category,margin_on_cost_percent",
+				"code,".$coefCategoryField.",pricelevel,targetrate,minrate",
+				"code,".$marginCategoryField.",margin_on_cost_percent",
 				"code,label",
 			),
 			'tabfieldvalue' => array(
-				"code,entity,code_commercial_category,pricelevel,targetrate,minrate",
-				"code,entity,code_commercial_category,margin_on_cost_percent",
+				"code,entity,".$coefCategoryField.",pricelevel,targetrate,minrate",
+				"code,entity,".$marginCategoryField.",margin_on_cost_percent",
 				$commercialCategoryFieldValue,
 			),
 			'tabfieldinsert' => array(
-				"code,entity,code_commercial_category,pricelevel,targetrate,minrate",
-				"code,entity,code_commercial_category,margin_on_cost_percent",
+				"code,entity,".$coefCategoryField.",pricelevel,targetrate,minrate",
+				"code,entity,".$marginCategoryField.",margin_on_cost_percent",
 				$commercialCategoryFieldValue,
 			),
 			'tabrowid' => array('rowid', 'rowid', 'rowid'),
@@ -298,6 +304,9 @@ class modDynamicsPrices extends DolibarrModules
 				'code' => $langs->trans('LMDB_CodeTooltipHelp'),
 				'entity' => $langs->trans('LMDB_ENtityTooltipHelp'),
 				'code_commercial_category' => $langs->trans('LMDB_CodeCommercialCategoryTooltipHelp'),
+				'fk_commercial_category' => $langs->trans('LMDB_FkCommercialCategoryTooltipHelp'),
+				'fk_nature' => $langs->trans('LMDB_FkNatureTooltipHelp'),
+				'code_nature' => $langs->trans('LMDB_CodeNatureTooltipHelp'),
 				'pricelevel' => $langs->trans('LMDB_PriceLevelTooltipHelp'),
 				'targetrate' => $langs->trans('LMDB_TargetRateTooltipHelp'),
 				'minrate' => $langs->trans('LMDB_MinRateTooltipHelp'),
@@ -634,6 +643,44 @@ class modDynamicsPrices extends DolibarrModules
 		$resql = $this->db->query($sql);
 
 		return ($resql && $this->db->num_rows($resql) > 0);
+	}
+
+	/**
+	 * Return first existing column from a list.
+	 *
+	 * @param string $tableName Table name
+	 * @param array<int,string> $columnNames Ordered column list
+	 * @return string
+	 */
+	private function getFirstExistingColumn($tableName, $columnNames)
+	{
+		foreach ($columnNames as $columnName) {
+			if ($this->columnExists($tableName, $columnName)) {
+				return $columnName;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Build SQL join condition between dictionary table and commercial category table.
+	 *
+	 * @param string $tableAlias Alias of dictionary table
+	 * @param string $columnName Commercial category column on dictionary table
+	 * @return string
+	 */
+	private function buildCommercialCategoryJoinCondition($tableAlias, $columnName)
+	{
+		if (empty($columnName)) {
+			return '1 = 0';
+		}
+
+		if (preg_match('/^fk_/', $columnName)) {
+			return 'cc.rowid = '.$tableAlias.'.'.$columnName;
+		}
+
+		return 'cc.code = '.$tableAlias.'.'.$columnName;
 	}
 
 	/**

--- a/langs/de_DE/dynamicsprices.lang
+++ b/langs/de_DE/dynamicsprices.lang
@@ -83,3 +83,13 @@ LMDB_AboutDescription = Allgemeine Informationen zum DynamicsPrices-Modul.
 
 LMDB_AboutGeneral = Allgemeine Informationen
 LMDB_AboutResources = Ressourcen
+
+LMDB_AboutVersion = Version
+LMDB_AboutFamily = Familie
+LMDB_AboutModuleDescription = Beschreibung
+LMDB_AboutMaintainer = Maintainer
+LMDB_AboutDocumentation = Dokumentation
+LMDB_AboutDocumentationLink = README öffnen
+LMDB_AboutSupport = Support
+LMDB_AboutSupportValue = Kontaktieren Sie den Maintainer für Support.
+LMDB_AboutContact = Kontakt

--- a/langs/en_US/dynamicsprices.lang
+++ b/langs/en_US/dynamicsprices.lang
@@ -83,3 +83,13 @@ LMDB_AboutDescription = General information about DynamicsPrices module.
 
 LMDB_AboutGeneral = General information
 LMDB_AboutResources = Resources
+
+LMDB_AboutVersion = Version
+LMDB_AboutFamily = Family
+LMDB_AboutModuleDescription = Description
+LMDB_AboutMaintainer = Maintainer
+LMDB_AboutDocumentation = Documentation
+LMDB_AboutDocumentationLink = Open README
+LMDB_AboutSupport = Support
+LMDB_AboutSupportValue = Contact the maintainer for support.
+LMDB_AboutContact = Contact

--- a/langs/es_ES/dynamicsprices.lang
+++ b/langs/es_ES/dynamicsprices.lang
@@ -83,3 +83,13 @@ LMDB_AboutDescription = Información general sobre el módulo DynamicsPrices.
 
 LMDB_AboutGeneral = Información general
 LMDB_AboutResources = Recursos
+
+LMDB_AboutVersion = Versión
+LMDB_AboutFamily = Familia
+LMDB_AboutModuleDescription = Descripción
+LMDB_AboutMaintainer = Mantenedor
+LMDB_AboutDocumentation = Documentación
+LMDB_AboutDocumentationLink = Abrir README
+LMDB_AboutSupport = Soporte
+LMDB_AboutSupportValue = Contacte al mantenedor para soporte.
+LMDB_AboutContact = Contacto

--- a/langs/fr_FR/dynamicsprices.lang
+++ b/langs/fr_FR/dynamicsprices.lang
@@ -85,3 +85,13 @@ LMDB_AboutDescription = Informations generales sur le module DynamicsPrices.
 
 LMDB_AboutGeneral = Informations generales
 LMDB_AboutResources = Ressources
+
+LMDB_AboutVersion = Version
+LMDB_AboutFamily = Famille
+LMDB_AboutModuleDescription = Description
+LMDB_AboutMaintainer = Mainteneur
+LMDB_AboutDocumentation = Documentation
+LMDB_AboutDocumentationLink = Ouvrir le README
+LMDB_AboutSupport = Support
+LMDB_AboutSupportValue = Contactez le mainteneur pour le support.
+LMDB_AboutContact = Contact

--- a/langs/it_IT/dynamicsprices.lang
+++ b/langs/it_IT/dynamicsprices.lang
@@ -83,3 +83,13 @@ LMDB_AboutDescription = Informazioni generali sul modulo DynamicsPrices.
 
 LMDB_AboutGeneral = Informazioni generali
 LMDB_AboutResources = Risorse
+
+LMDB_AboutVersion = Versione
+LMDB_AboutFamily = Famiglia
+LMDB_AboutModuleDescription = Descrizione
+LMDB_AboutMaintainer = Manutentore
+LMDB_AboutDocumentation = Documentazione
+LMDB_AboutDocumentationLink = Apri README
+LMDB_AboutSupport = Supporto
+LMDB_AboutSupportValue = Contattare il manutentore per il supporto.
+LMDB_AboutContact = Contatto


### PR DESCRIPTION
### Motivation
- Corriger l'erreur fatale causée par des inclusions et clés de traduction pointant vers le module Diffusion au lieu de DynamicsPrices sur la page admin/about.php.
- Éviter les textes en dur et assurer la cohérence i18n en ajoutant les clés de traduction manquantes pour la page "À propos".

### Description
- Remplacement des inclusions incorrectes par `../lib/dynamicsprices.lib.php` et `../core/modules/modDynamicsPrices.class.php` et instanciation de `modDynamicsPrices` au lieu de `modDiffusion` dans `admin/about.php`.
- Chargement des traductions via `dynamicsprices@dynamicsprices`, utilisation de `dynamicspricesAdminPrepareHead()` et correction du titre/onglet/texte affichés pour pointer vers DynamicsPrices.
- Mise à jour du lien de documentation vers `/dynamicsprices/README.md` et remplacement de toutes les clés de langue Diffusion par les clés `LMDB_About*` du module DynamicsPrices.
- Ajout des clés de traduction manquantes (`LMDB_AboutVersion`, `LMDB_AboutFamily`, `LMDB_AboutModuleDescription`, `LMDB_AboutMaintainer`, `LMDB_AboutDocumentation`, `LMDB_AboutDocumentationLink`, `LMDB_AboutSupport`, `LMDB_AboutSupportValue`, `LMDB_AboutContact`) dans `en_US`, `fr_FR`, `de_DE`, `es_ES` et `it_IT`.

### Testing
- Vérification de la syntaxe PHP avec `php -l admin/about.php`, résultat : succès (pas d'erreurs de syntaxe).
- Recherche des anciennes références avec `rg -n "diffusion|modDiffusion|Diffusion" admin/about.php`, résultat : aucune référence restante.
- Changements commités et vérifiés en local (commit HEAD court : `f141c26`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c80a606e2c832eb4b842875ba5e5f6)